### PR TITLE
new implementation of prelu

### DIFF
--- a/nobuco/node_converters/math.py
+++ b/nobuco/node_converters/math.py
@@ -59,13 +59,13 @@ def converter_mean(input: Tensor, dim=None, keepdim: _bool = False, *, dtype: Op
             return out
     return func
 
-@converter(torch.sin, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
+@converter(torch.sin, torch.Tensor.sin, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
 def converter_sin(input, *args, **kwargs):
     def func(input, *args, **kwargs):
         return tf.math.sin(input)
     return func
 
-@converter(torch.cos, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
+@converter(torch.cos, torch.Tensor.cos, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
 def converter_cos(input, *args, **kwargs):
     def func(input, *args, **kwargs):
         return tf.math.cos(input)


### PR DESCRIPTION
I implement the operation of `PLeLU`.

![image](https://user-images.githubusercontent.com/84084372/235679716-46b46133-331e-4877-a72f-b73de3b8c8fa.png)

But, I have some limitations.

- Implementation of `nn.PReLU`
    - I have no idea of implementation of `nn.PReLU`

- Implementation of alpha (in `torch.nn.functional.prelu`, `torch.prelu`, `torch.Tensor.prelu`)
    - When I trying to receive the weight of `prelu` by specifying alpha, an unknown error occurs.
    - Below is the error I get
    - 
```
You are passing KerasTensor(type_spec=VariableSpec(shape=(), dtype=tf.float32, trainable=True, alias_id=None),
 name='weight:0', description="created by layer 'weight_layer'"), an intermediate Keras symbolic input/output, to a 
TF API that does not allow registering custom dispatchers, such as `tf.cond`, `tf.function`, gradient tapes, or `tf.map_fn`.
 Keras Functional model construction only supports TF API calls that *do* support dispatching, such as `tf.math.add` or
 `tf.reshape`. Other APIs cannot be called directly on symbolic Kerasinputs/outputs. You can work around this limitation
 by putting the operation in a custom Keras layer `call` and calling that layer on this symbolic input/output.
```

<br>
<br>

Can you advise for me?