### PR TITLE
Added nn.GELU activation

### DIFF
--- a/nobuco/node_converters/activation.py
+++ b/nobuco/node_converters/activation.py
@@ -155,3 +155,11 @@ def converter_clip(input: Tensor, min: Optional[Tensor]=None, max: Optional[Tens
     def func(input, min=None, max=None, *, out=None):
         return tf.clip_by_value(input, min, max)
     return func
+
+
+@converter(F.gelu, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
+def converter_gelu(input: Tensor, approximate: bool = False):
+    def func(input: Tensor, approximate):
+        return tf.keras.activations.gelu(input, approximate=approximate)
+    return func
+

--- a/nobuco/node_converters/activation.py
+++ b/nobuco/node_converters/activation.py
@@ -154,6 +154,7 @@ def converter_softmax(input: Tensor, dim: Union[str, None], *, dtype: Optional[_
 def converter_clip(input: Tensor, min: Optional[Tensor]=None, max: Optional[Tensor]=None, *, out: Optional[Tensor]=None):
     def func(input, min=None, max=None, *, out=None):
         return tf.clip_by_value(input, min, max)
+    return func
 
 
 @converter(F.gelu, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)

--- a/nobuco/node_converters/activation.py
+++ b/nobuco/node_converters/activation.py
@@ -150,16 +150,14 @@ def converter_softmax(input: Tensor, dim: Union[str, None], *, dtype: Optional[_
     return func
 
 
-@converter(torch.clip, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
-def converter_clip(input: Tensor, min: Optional[Tensor]=None, max: Optional[Tensor]=None, *, out: Optional[Tensor]=None):
-    def func(input, min=None, max=None, *, out=None):
-        return tf.clip_by_value(input, min, max)
-    return func
-
-
 @converter(F.gelu, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
-def converter_gelu(input: Tensor, approximate: bool = False):
-    def func(input: Tensor, approximate):
-        return tf.nn.gelu(input, approximate=approximate)
+def converter_gelu(input: Tensor, approximate='none'):
+    def func(input: Tensor, approximate='none'):
+        if approximate.lower() == 'none':
+            # Gaussian Error Linear Units (GELUs)
+            # https://arxiv.org/abs/1606.08415
+            return input * 0.5 * (1 + tf.math.erf(input / tf.math.sqrt(2.)))
+        else:
+            return tf.nn.gelu(input, approximate=approximate)
     return func
 

--- a/nobuco/node_converters/activation.py
+++ b/nobuco/node_converters/activation.py
@@ -150,6 +150,12 @@ def converter_softmax(input: Tensor, dim: Union[str, None], *, dtype: Optional[_
     return func
 
 
+@converter(torch.clip, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
+def converter_clip(input: Tensor, min: Optional[Tensor]=None, max: Optional[Tensor]=None, *, out: Optional[Tensor]=None):
+    def func(input, min=None, max=None, *, out=None):
+        return tf.clip_by_value(input, min, max)
+
+
 @converter(F.gelu, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
 def converter_gelu(input: Tensor, approximate='none'):
     def func(input: Tensor, approximate='none'):
@@ -160,4 +166,3 @@ def converter_gelu(input: Tensor, approximate='none'):
         else:
             return tf.nn.gelu(input, approximate=approximate)
     return func
-

--- a/nobuco/node_converters/activation.py
+++ b/nobuco/node_converters/activation.py
@@ -160,6 +160,6 @@ def converter_clip(input: Tensor, min: Optional[Tensor]=None, max: Optional[Tens
 @converter(F.gelu, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
 def converter_gelu(input: Tensor, approximate: bool = False):
     def func(input: Tensor, approximate):
-        return tf.keras.activations.gelu(input, approximate=approximate)
+        return tf.nn.gelu(input, approximate=approximate)
     return func
 


### PR DESCRIPTION
nn.GELU(approximate='none')
![nn.GELU(approximate='none')](https://github.com/AlexanderLutsenko/nobuco/assets/67783710/8a948657-dd91-4e6b-8bc5-ef5541644a66)

nn.GELU(approximate='tanh')
![tanh](https://github.com/AlexanderLutsenko/nobuco/assets/67783710/bff33494-537e-41b9-bb79-e6861f55d78e)

Outputs with PyTorch and Keras model with `approximate='none'` passed `np.testing.assert_allclose` with `atol=1e-3, rtol=1e-3` and 7% mismatch with `atol=1e-4, rtol=1e-4`

'none' and 'tanh'
![image (1)](https://github.com/AlexanderLutsenko/nobuco/assets/67783710/25496e13-7033-49f0-b6f5-2c844130e53f)


