### PR TITLE
Added nn.SiLU activation

### DIFF
--- a/nobuco/node_converters/activation.py
+++ b/nobuco/node_converters/activation.py
@@ -155,3 +155,10 @@ def converter_clip(input: Tensor, min: Optional[Tensor]=None, max: Optional[Tens
     def func(input, min=None, max=None, *, out=None):
         return tf.clip_by_value(input, min, max)
     return func
+
+
+@converter(F.silu, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
+def converter_silu(input: Tensor, inplace=False):
+    def func(input: Tensor, inplace=False):
+        return tf.nn.silu(input, beta=1.0)
+    return func


### PR DESCRIPTION
Added nn.SiLU actication

Since PyTorch version only supports beta = 1.0 (no argument for beta), TF version with only beta=1.0

```python
@converter(F.silu, channel_ordering_strategy=ChannelOrderingStrategy.MINIMUM_TRANSPOSITIONS)
def converter_silu(input: Tensor, inplace=False):
    def func(input: Tensor, inplace=False):
        return tf.nn.silu(input, beta=1.0)
    return func
```

nn.SiLU() (inplace=False default argument value)
![silu](https://github.com/AlexanderLutsenko/nobuco/assets/67783710/b79bf006-46d6-4f74-b24a-986027176e9f)
