### PR TITLE
FIX #31: failed to conversion a convolution when padding argument is 'valid' or default

### DIFF
--- a/nobuco/node_converters/convolution.py
+++ b/nobuco/node_converters/convolution.py
@@ -50,10 +50,11 @@ def converter_Conv1d(self, input: Tensor):
     pad_str = 'valid'
     pad_layer = None
 
-    if padding == 'same':
-        pad_str = 'same'
-    elif padding != (0,):
-        pad_layer = keras.layers.ZeroPadding1D(padding[0])
+    if padding != 'valid':
+        if padding == 'same':
+            pad_str = 'same'
+        elif padding != (0,):
+            pad_layer = keras.layers.ZeroPadding1D(padding[0])
 
     if is_depthwise:
         conv = keras.layers.DepthwiseConv1D(
@@ -118,10 +119,11 @@ def converter_conv1d(input: Tensor, weight: Tensor, bias: Optional[Tensor] = Non
     pad_str = 'valid'
     pad_layer = None
 
-    if padding == 'same':
-        pad_str = 'same'
-    elif padding != (0,):
-        pad_layer = keras.layers.ZeroPadding1D(padding[0])
+    if padding != 'valid':
+        if padding == 'same':
+            pad_str = 'same'
+        elif padding != (0,):
+            pad_layer = keras.layers.ZeroPadding1D(padding[0])
 
     if is_depthwise:
         conv = keras.layers.DepthwiseConv1D(
@@ -329,10 +331,11 @@ def converter_Conv2d(self, input: Tensor):
     pad_str = 'valid'
     pad_layer = None
 
-    if padding == 'same':
-        pad_str = 'same'
-    elif padding != (0, 0):
-        pad_layer = keras.layers.ZeroPadding2D(padding)
+    if padding != 'valid':
+        if padding == 'same':
+            pad_str = 'same'
+        elif padding != (0, 0):
+            pad_layer = keras.layers.ZeroPadding2D(padding)
 
     if is_depthwise:
         conv = keras.layers.DepthwiseConv2D(
@@ -400,10 +403,11 @@ def converter_conv2d(input: Tensor, weight: Tensor, bias: Optional[Tensor] = Non
     pad_str = 'valid'
     pad_layer = None
 
-    if padding == 'same':
-        pad_str = 'same'
-    elif padding != (0, 0):
-        pad_layer = keras.layers.ZeroPadding2D(padding)
+    if padding != 'valid':
+        if padding == 'same':
+            pad_str = 'same'
+        elif padding != (0, 0):
+            pad_layer = keras.layers.ZeroPadding2D(padding)
 
     if is_depthwise:
         conv = keras.layers.DepthwiseConv2D(


### PR DESCRIPTION
This PR is for #31

From my own investigation, it seems that the cause is that `valid` is passed to `ZeroPadding()` in the following part of the conversion function for each convolution in `node_converters/convolution.py`.

```python
if padding == 'same':
    pad_str = 'same'
elif padding != (0, 0):
    pad_layer = keras.layers.ZeroPadding2D(padding)
```

Therefore, I have added an if statement to make sure that the `padding` is not `valid`.

```python
if padding != 'valid':
    if padding == 'same':
        pad_str = 'same'
    elif padding != (0, 0):
        pad_layer = keras.layers.ZeroPadding2D(padding)
```

I would like to have your review to this PR.
