### PR TITLE
Extended return

### DIFF
--- a/nobuco/convert.py
+++ b/nobuco/convert.py
@@ -260,10 +260,9 @@ def pytorch_to_keras(
         constants_to_variables: bool = True,
         full_validation: bool = True,
         validation_tolerance: float = 1e-4,
-        return_outputs_pt: bool = False,
         save_trace_html: bool = False,
         debug_traces: TraceLevel = TraceLevel.DEFAULT,
-) -> keras.Model | Tuple[keras.Model, object]:
+) -> Tuple[keras.Model, object, Dict[PytorchNode, ValidationResult], Dict[PytorchNode, ConversionResult]]:
     """Converts Pytorch program to Keras graph
 
     Args:
@@ -364,8 +363,5 @@ def pytorch_to_keras(
     elapsed = time.time() - start
     print(f'Conversion complete. Elapsed time: {elapsed:.2f} sec.')
 
-    if return_outputs_pt:
-        outputs_pt = node_hierarchy.node.outputs
-        return keras_model, outputs_pt
-    else:
-        return keras_model
+    outputs_pt = node_hierarchy.node.outputs
+    return keras_model, outputs_pt, validation_result_dict, conversion_result_dict


### PR DESCRIPTION
Developers will want to programmatically analyze the result of conversion in a more detailed manner. Therefore, I suggest returning the validation and conversion results as well after conversion.

From the perspective of Clean Code, it's better to return a consistent type. See the examples below. If we use a `Union` as the return type, your IDE will be confused about the type of the returned variables.

In the case of `func`, the `second` variable must be an `int`, but we can see that Intellisense recommends autocompletion from both `int` and `str`.
In the case of `func2`, the autocompletion is limited to the designed targets.

![func_int](https://github.com/user-attachments/assets/9d75293c-3977-40b6-9195-59562d8525d0)
![func_str](https://github.com/user-attachments/assets/5bc8ba8c-d151-4127-8268-95995c2d6d27)
![func2_int](https://github.com/user-attachments/assets/58f514cf-5a6d-409d-9390-5c33443e7a7c)
![func2_list](https://github.com/user-attachments/assets/35985f6a-99ce-411d-ae0a-b52ddc539957)
