### PR TITLE
color traceback on error messages / upgraded progressbar

### DIFF
--- a/examples/multihead-attention.py
+++ b/examples/multihead-attention.py
@@ -2,6 +2,7 @@ import os
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 import nobuco
+from nobuco import ChannelOrder, ChannelOrderingStrategy
 from nobuco.layers.weight import WeightLayer
 
 import torch
@@ -10,6 +11,7 @@ from torch import nn
 import tensorflow as tf
 from tensorflow.lite.python.lite import TFLiteConverter
 import keras
+
 import numpy as np
 
 class MultiheadAttentionModel(nn.Module):
@@ -27,8 +29,65 @@ class MultiheadAttentionModel(nn.Module):
         # Reshape output back to (batch_size, embed_dim, seq_len)
         return attn_output.permute(1, 2, 0)
 
+class CustomMultiHeadAttention(keras.layers.Layer):
+    def __init__(self, d_model, num_heads):
+        super().__init__()
+        self.d_model = d_model
+        self.num_heads = num_heads
+        
+        assert d_model % num_heads == 0
+        self.depth = d_model // num_heads
+        
+        self.wq = keras.layers.Dense(d_model)
+        self.wk = keras.layers.Dense(d_model)
+        self.wv = keras.layers.Dense(d_model)
+        
+        self.dense = keras.layers.Dense(d_model)
+
+    def split_heads(self, x, batch_size):
+        x = tf.reshape(x, (batch_size, -1, self.num_heads, self.depth))
+        return tf.transpose(x, perm=[0, 2, 1, 3])
+
+    def call(self, q, k, v):
+        batch_size = tf.shape(q)[0]
+        
+        q = self.wq(q)
+        k = self.wk(k)
+        v = self.wv(v)
+        
+        q = self.split_heads(q, batch_size)
+        k = self.split_heads(k, batch_size)
+        v = self.split_heads(v, batch_size)
+        
+        scaled_attention, attention_weights = self.scaled_dot_product_attention(q, k, v)
+        
+        scaled_attention = tf.transpose(scaled_attention, perm=[0, 2, 1, 3])
+        concat_attention = tf.reshape(scaled_attention, (batch_size, -1, self.d_model))
+        
+        output = self.dense(concat_attention)
+        return output, attention_weights
+
+    def scaled_dot_product_attention(self, q, k, v):
+        matmul_qk = tf.matmul(q, k, transpose_b=True)
+        dk = tf.cast(tf.shape(k)[-1], tf.float32)
+        scaled_attention_logits = matmul_qk / tf.math.sqrt(dk)
+        attention_weights = tf.nn.softmax(scaled_attention_logits, axis=-1)
+        output = tf.matmul(attention_weights, v)
+        return output, attention_weights
+
+@nobuco.converter(MultiheadAttentionModel, channel_ordering_strategy=ChannelOrderingStrategy.FORCE_PYTORCH_ORDER)
+def converter_MultiheadAttentionModel(self, x):
+    custom_mha = CustomMultiHeadAttention(d_model=128, num_heads=8)
+    
+    def func(x):
+        x = tf.transpose(x, perm=[2, 0, 1])  # (seq_len, batch_size, embed_dim)
+        output, _ = custom_mha(x, x, x)
+        return tf.transpose(output, perm=[1, 2, 0])  # (batch_size, embed_dim, seq_len)
+    
+    return func
+
 # Create the model
-model = MultiheadAttentionModel()
+model = MultiheadAttentionModel().eval()
 
 # Create a dummy input tensor
 dummy_input = torch.randn(1, 128, 4096)  # (batch_size, embed_dim, seq_len)
@@ -36,7 +95,9 @@ dummy_input = torch.randn(1, 128, 4096)  # (batch_size, embed_dim, seq_len)
 # Convert PyTorch model to Keras
 keras_model = nobuco.pytorch_to_keras(
     model,
-    args=[dummy_input]
+    args=[dummy_input],
+    inputs_channel_order=ChannelOrder.PYTORCH,
+    outputs_channel_order=ChannelOrder.PYTORCH
 )
 
 # Save the Keras model
@@ -45,7 +106,7 @@ keras_model.save(model_path + '.h5')
 print('Model saved')
 
 # Define custom objects
-custom_objects = {'WeightLayer': WeightLayer}
+custom_objects = {'WeightLayer': WeightLayer, 'CustomMultiHeadAttention': CustomMultiHeadAttention}
 
 # Load the Keras model
 keras_model_restored = keras.models.load_model(model_path + '.h5', custom_objects=custom_objects)
@@ -62,9 +123,10 @@ with open(model_path + '.tflite', 'wb') as f:
 print('TFLite model saved')
 
 # Test the models
-pytorch_output = model(dummy_input)
+with torch.no_grad():
+    pytorch_output = model(dummy_input)
 keras_output = keras_model.predict(dummy_input.numpy())
 
 print("PyTorch output shape:", pytorch_output.shape)
 print("Keras output shape:", keras_output.shape)
-print("Output difference:", np.abs(pytorch_output.detach().numpy() - keras_output).max())
+print("Output difference:", np.abs(pytorch_output.numpy() - keras_output).max())

--- a/examples/multihead-attention.py
+++ b/examples/multihead-attention.py
@@ -1,0 +1,70 @@
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+import nobuco
+from nobuco.layers.weight import WeightLayer
+
+import torch
+from torch import nn
+
+import tensorflow as tf
+from tensorflow.lite.python.lite import TFLiteConverter
+import keras
+import numpy as np
+
+class MultiheadAttentionModel(nn.Module):
+    def __init__(self, embed_dim=128, num_heads=8):
+        super().__init__()
+        self.multihead_attn = nn.MultiheadAttention(embed_dim, num_heads)
+
+    def forward(self, x):
+        # Reshape input to (seq_len, batch_size, embed_dim)
+        x = x.permute(2, 0, 1)
+        
+        # Self-attention: use the same tensor for query, key, and value
+        attn_output, _ = self.multihead_attn(x, x, x)
+        
+        # Reshape output back to (batch_size, embed_dim, seq_len)
+        return attn_output.permute(1, 2, 0)
+
+# Create the model
+model = MultiheadAttentionModel()
+
+# Create a dummy input tensor
+dummy_input = torch.randn(1, 128, 4096)  # (batch_size, embed_dim, seq_len)
+
+# Convert PyTorch model to Keras
+keras_model = nobuco.pytorch_to_keras(
+    model,
+    args=[dummy_input]
+)
+
+# Save the Keras model
+model_path = 'multihead_attention'
+keras_model.save(model_path + '.h5')
+print('Model saved')
+
+# Define custom objects
+custom_objects = {'WeightLayer': WeightLayer}
+
+# Load the Keras model
+keras_model_restored = keras.models.load_model(model_path + '.h5', custom_objects=custom_objects)
+print('Model loaded')
+
+# Convert to TFLite
+converter = TFLiteConverter.from_keras_model_file(model_path + '.h5', custom_objects=custom_objects)
+converter.target_ops = [tf.lite.OpsSet.SELECT_TF_OPS, tf.lite.OpsSet.TFLITE_BUILTINS]
+tflite_model = converter.convert()
+
+# Save the TFLite model
+with open(model_path + '.tflite', 'wb') as f:
+    f.write(tflite_model)
+print('TFLite model saved')
+
+# Test the models
+pytorch_output = model(dummy_input)
+keras_output = keras_model.predict(dummy_input.numpy())
+
+print("PyTorch output shape:", pytorch_output.shape)
+print("Keras output shape:", keras_output.shape)
+print("Output difference:", np.abs(pytorch_output.detach().numpy() - keras_output).max())

--- a/examples/resnet50_fpn.py
+++ b/examples/resnet50_fpn.py
@@ -1,0 +1,48 @@
+import urllib
+import PIL.Image
+from torchvision.models.detection import FCOS_ResNet50_FPN_Weights
+
+import nobuco
+from nobuco import ChannelOrder, ChannelOrderingStrategy
+from nobuco.layers.weight import WeightLayer
+
+import torch
+import torchvision
+
+import tensorflow as tf
+import keras
+
+
+model = torchvision.models.detection.fcos_resnet50_fpn(weights="DEFAULT")
+model.eval()
+
+categoties = FCOS_ResNet50_FPN_Weights.DEFAULT.meta['categories']
+print(categoties)
+
+urllib.request.urlretrieve('https://pytorch.org/tutorials/_images/cat_224x224.jpg', "cat_224x224.jpg")
+image_pil = PIL.Image.open("cat_224x224.jpg").resize((640, 640))
+
+image_pt = torchvision.transforms.functional.pil_to_tensor(image_pil).to(torch.float32)[None] / 255
+
+keras_model, outputs_pt = nobuco.pytorch_to_keras(
+    model,
+    args=[image_pt],
+    kwargs=None,
+    inputs_channel_order=ChannelOrder.TENSORFLOW,
+    outputs_channel_order=ChannelOrder.TENSORFLOW,
+    enable_torch_tracing=True,
+    return_outputs_pt=True
+)
+print('Output classes:', [categoties[i] for i in outputs_pt[1][0]["labels"]])
+
+model_path = 'resnet50_fpn'
+keras_model.save(model_path)
+print('Model saved')
+
+custom_objects = {'WeightLayer': WeightLayer}
+keras_model_restored = keras.models.load_model(model_path, custom_objects=custom_objects)
+print('Model loaded')
+
+image_np = tf.keras.utils.img_to_array(image_pil)[None] / 255
+_, _, output_classes = keras_model_restored(image_np)
+print('Output classes:', [categoties[i] for i in output_classes])

--- a/nobuco/convert.py
+++ b/nobuco/convert.py
@@ -156,20 +156,28 @@ def convert_hierarchy(
                 keras_op = convert_node(node, node_converter)
                 node_is_reusable = node_converter.reusable
             except Exception as e:
-                console.print(Panel(f"[bold red]Conversion exception on node '[cyan]{node.get_type().__name__}[/cyan]'", 
-                                    title="Conversion Error", expand=False))
-                console.print(f"[yellow]Error message:[/yellow] {str(e)}")
-                
-                tb = Traceback()
-                console.print(tb)
-                
-                if hasattr(node, 'wrapped_op') and hasattr(node.wrapped_op, 'op'):
-                    op_source = inspect.getsource(node.wrapped_op.op)
-                    console.print("[yellow]Original operation source:[/yellow]")
-                    console.print(Syntax(op_source, "python", theme="monokai", line_numbers=True))
-                
-                keras_op = FailedConversionStub(node.get_op())
-                console.print("[red]Using FailedConversionStub for this node.[/red]")
+                try:
+                    console.print(Panel(f"[bold red]Conversion exception on node '[cyan]{node.get_type().__name__}[/cyan]'",
+                                        title="Conversion Error", expand=False))
+                    console.print(f"[yellow]Error message:[/yellow] {str(e)}")
+            
+                    tb = Traceback()
+                    console.print(tb)
+            
+                    if hasattr(node, 'wrapped_op') and hasattr(node.wrapped_op, 'op'):
+                        op_source = inspect.getsource(node.wrapped_op.op)
+                        console.print("[yellow]Original operation source:[/yellow]")
+                        console.print(Syntax(op_source, "python", theme="monokai", line_numbers=True))
+            
+                    console.print("[red]Using FailedConversionStub for this node.[/red]")
+                except Exception as rich_error:
+                    # Fallback to simple print if Rich console fails
+                    print(f"Conversion exception on node '{node.get_type().__name__}': {str(e)}")
+                    print(f"Rich console error: {str(rich_error)}")
+                finally:
+                    keras_op = FailedConversionStub(node.get_op())
+                    node_is_reusable = False
+
             
 
 

--- a/nobuco/convert.py
+++ b/nobuco/convert.py
@@ -360,14 +360,12 @@ def pytorch_to_keras(
     with ProgressBar("Tracing", total=None) as progress_bar:
         node_hierarchy = Tracer.trace(model, trace_shape, enable_torch_tracing, args, kwargs, progress_bar)
 
-
     with ProgressBar("Converting", total=node_hierarchy.get_op_count()) as progress_bar:
         keras_converted_node = convert_hierarchy(node_hierarchy, CONVERTER_DICT,
                                                 reuse_layers=True, full_validation=full_validation, constants_to_variables=constants_to_variables,
                                                 tolerance=validation_tolerance,
                                                 progress_bar=progress_bar,
                                                 )
-
 
     validation_result_dict = collect_validation_results(keras_converted_node)
     conversion_result_dict = collect_conversion_results(keras_converted_node)

--- a/nobuco/converters/validation.py
+++ b/nobuco/converters/validation.py
@@ -1,4 +1,3 @@
-import traceback
 import warnings
 from enum import Enum
 import math
@@ -12,18 +11,20 @@ from nobuco.locate.link import get_link_to_obj
 from nobuco.util import str_parents, collect_recursively
 
 
+# Import rich for colored tracebacks
+from rich import print as rprint
+from rich.traceback import Traceback
+
 class ValidationStatus(Enum):
     SUCCESS = 1
     FAIL = 2
     INACCURATE = 3
-
 
 class ValidationResult:
     def __init__(self, diff_abs: float, diff_rel: float, status: ValidationStatus):
         self.diff_abs = diff_abs
         self.diff_rel = diff_rel
         self.status = status
-
 
 class ConversionResult:
     def __init__(self, converted_manually, is_implemented=True, is_duplicate=False, connectivity_status=None, converter=None):
@@ -41,7 +42,6 @@ class ConversionResult:
             location_link = get_link_to_obj(convert_func)
             return location_link
 
-
 def validate(node, pytorch_op, keras_op, input_args, input_kwargs, output_tensors, op_type, tolerance=1e-4) -> ValidationResult:
     try:
         diffs = validate_diff_default(keras_op, pytorch_op, input_args, input_kwargs, output_tensors)
@@ -58,9 +58,11 @@ def validate(node, pytorch_op, keras_op, input_args, input_kwargs, output_tensor
         return ValidationResult(diff_abs, diff_rel, status)
     except Exception as e:
         warnings.warn(f"Validation exception on node '{op_type.__name__}': {e}")
-        traceback.print_exc()
+        # Use rich to print the traceback in color
+        from rich.traceback import Traceback
+        tb = Traceback()
+        rprint(tb)
         return ValidationResult(None, None, ValidationStatus.FAIL)
-
 
 def validate_diff_default(keras_op, pytorch_op, args_pt, kwargs_pt, outputs_pt, is_training=False):
     args_tf = pytorch2keras_recursively(args_pt, channel_order=ChannelOrder.TENSORFLOW)

--- a/nobuco/converters/validation.py
+++ b/nobuco/converters/validation.py
@@ -98,7 +98,7 @@ def validate(node, pytorch_op, keras_op, input_args, input_kwargs, output_tensor
         # console.print_exception(show_locals=True)
 
         # Optionally, issue a warning (this will not be colored)
-        warnings.warn(error_message)
+        # warnings.warn(error_message)
 
         return ValidationResult(None, None, ValidationStatus.FAIL, error_message)
 

--- a/nobuco/trace/trace.py
+++ b/nobuco/trace/trace.py
@@ -235,8 +235,10 @@ class Tracer:
     def all_tensors_equal(tensors1, tensors2):
         tensors1 = collect_recursively(tensors1, torch.Tensor)
         tensors2 = collect_recursively(tensors2, torch.Tensor)
-        assert len(tensors1) == len(tensors2)
-        return all(torch.equal(t1.cpu(), t2.cpu()) for t1, t2 in zip(tensors1, tensors2))
+        if len(tensors1) == len(tensors2):
+            return all(torch.equal(t1.cpu(), t2.cpu()) for t1, t2 in zip(tensors1, tensors2))
+        else:
+            return False
 
     @staticmethod
     def module_forward_tracing_decorator(forward_func):

--- a/nobuco/vis/progress.py
+++ b/nobuco/vis/progress.py
@@ -1,16 +1,36 @@
-import sys
-from tqdm import tqdm
-
+from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn
+from rich.console import Console
+import time
 
 class ProgressBar:
     def __init__(self, prefix, total=None, bar_format=None):
         self.prefix = prefix
-        self.bar = tqdm(file=sys.stdout, total=total, bar_format=bar_format)
-        self.bar.set_description_str(f"[Nobuco] {self.prefix}")
+        self.total = total
+        self.console = Console()
+        self.progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TextColumn("[progress.elapsed]{task.elapsed}"),
+            console=self.console,
+            transient=True
+        )
+        self.task = None
+        self.start_time = time.time()
+
+    def __enter__(self):
+        self.progress.start()
+        self.task = self.progress.add_task(f"[bold blue][Nobuco] {self.prefix}", total=self.total)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     def update(self, n=1):
-        self.bar.update(n)
+        self.progress.update(self.task, advance=n)
 
     def close(self):
-        self.bar.set_description_str(f"[Nobuco] {self.prefix} (DONE)")
-        self.bar.close()
+        elapsed = time.time() - self.start_time
+        self.progress.stop()
+        self.console.print(f"[bold green][Nobuco] {self.prefix} (DONE) - Elapsed time: {elapsed:.2f} sec")

--- a/nobuco/vis/progress.py
+++ b/nobuco/vis/progress.py
@@ -1,36 +1,59 @@
-from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn
+from tqdm import tqdm
 from rich.console import Console
 import time
+import warnings
 
 class ProgressBar:
     def __init__(self, prefix, total=None, bar_format=None):
         self.prefix = prefix
         self.total = total
         self.console = Console()
-        self.progress = Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            TextColumn("[progress.elapsed]{task.elapsed}"),
-            console=self.console,
-            transient=True
-        )
-        self.task = None
         self.start_time = time.time()
+        
+        try:
+            # Attempt to use tqdm.rich
+            from tqdm.rich import tqdm as rich_tqdm
+            self.bar = rich_tqdm(
+                total=total,
+                desc=f"[Nobuco] {self.prefix}",
+                bar_format=bar_format,
+                colour="blue",
+                unit="ops"
+            )
+        except Exception:
+            # Fallback to standard tqdm
+            warnings.warn("Failed to initialize tqdm.rich. Falling back to standard tqdm.", RuntimeWarning)
+            self.bar = tqdm(
+                total=total,
+                desc=f"[Nobuco] {self.prefix}",
+                bar_format=bar_format,
+                unit="ops"
+            )
 
     def __enter__(self):
-        self.progress.start()
-        self.task = self.progress.add_task(f"[bold blue][Nobuco] {self.prefix}", total=self.total)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
     def update(self, n=1):
-        self.progress.update(self.task, advance=n)
+        try:
+            self.bar.update(n)
+        except Exception:
+            pass  # Silently ignore update errors
 
     def close(self):
+        try:
+            self.bar.set_description_str(f"[Nobuco] {self.prefix} (DONE)")
+            self.bar.close()
+        except Exception:
+            warnings.warn("Error occurred while closing the progress bar.", RuntimeWarning)
+        
         elapsed = time.time() - self.start_time
-        self.progress.stop()
         self.console.print(f"[bold green][Nobuco] {self.prefix} (DONE) - Elapsed time: {elapsed:.2f} sec")
+
+    def __del__(self):
+        try:
+            self.close()
+        except:
+            pass  # Ignore any errors during garbage collection

--- a/nobuco/vis/progress.py
+++ b/nobuco/vis/progress.py
@@ -2,12 +2,11 @@ from tqdm import tqdm
 import time
 import warnings
 
+
 class ProgressBar:
     def __init__(self, prefix, total=None, bar_format=None):
         self.prefix = prefix
         self.total = total
-        self.start_time = time.time()
-        
         self.bar = tqdm(
             total=total,
             desc=f"[Nobuco] {self.prefix}",
@@ -34,9 +33,6 @@ class ProgressBar:
         except Exception:
             warnings.warn("Error occurred while closing the progress bar.", RuntimeWarning)
         
-        elapsed = time.time() - self.start_time
-        print(f"\n[Nobuco] {self.prefix} (DONE) - Elapsed time: {elapsed:.2f} sec")
-
     def __del__(self):
         try:
             self.close()

--- a/nobuco/vis/progress.py
+++ b/nobuco/vis/progress.py
@@ -1,5 +1,4 @@
 from tqdm import tqdm
-from rich.console import Console
 import time
 import warnings
 
@@ -7,28 +6,14 @@ class ProgressBar:
     def __init__(self, prefix, total=None, bar_format=None):
         self.prefix = prefix
         self.total = total
-        self.console = Console()
         self.start_time = time.time()
         
-        try:
-            # Attempt to use tqdm.rich
-            from tqdm.rich import tqdm as rich_tqdm
-            self.bar = rich_tqdm(
-                total=total,
-                desc=f"[Nobuco] {self.prefix}",
-                bar_format=bar_format,
-                colour="blue",
-                unit="ops"
-            )
-        except Exception:
-            # Fallback to standard tqdm
-            warnings.warn("Failed to initialize tqdm.rich. Falling back to standard tqdm.", RuntimeWarning)
-            self.bar = tqdm(
-                total=total,
-                desc=f"[Nobuco] {self.prefix}",
-                bar_format=bar_format,
-                unit="ops"
-            )
+        self.bar = tqdm(
+            total=total,
+            desc=f"[Nobuco] {self.prefix}",
+            bar_format=bar_format,
+            unit="ops"
+        )
 
     def __enter__(self):
         return self
@@ -44,13 +29,13 @@ class ProgressBar:
 
     def close(self):
         try:
-            self.bar.set_description_str(f"[Nobuco] {self.prefix} (DONE)")
+            self.bar.set_description(f"[Nobuco] {self.prefix} (DONE)")
             self.bar.close()
         except Exception:
             warnings.warn("Error occurred while closing the progress bar.", RuntimeWarning)
         
         elapsed = time.time() - self.start_time
-        self.console.print(f"[bold green][Nobuco] {self.prefix} (DONE) - Elapsed time: {elapsed:.2f} sec")
+        print(f"\n[Nobuco] {self.prefix} (DONE) - Elapsed time: {elapsed:.2f} sec")
 
     def __del__(self):
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nobuco"
-version = "0.16.4"
+version = "0.16.5"
 description = "Pytorch to Tensorflow conversion made intuitive"
 readme = "README.md"
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torchvision==0.16.1
 torchaudio==2.1.1
 tensorflow==2.15.0.post1
 sty>=1.0.0
+rich


### PR DESCRIPTION
this is commented out - 
console.print_exception(show_locals=True) - but it will show the tensors in question
like this 
<img width="813" alt="Screenshot 2024-10-17 at 12 39 00 PM" src="https://github.com/user-attachments/assets/d52170aa-031d-44ac-94a1-dcff1c313dd3">

otherwise - by default will just show shorter message in color
<img width="1326" alt="Screenshot 2024-10-17 at 12 40 53 PM" src="https://github.com/user-attachments/assets/bc9f50f9-e9e0-46d1-954b-3f9c2fdf4b97">

